### PR TITLE
fix for lazy load on iOS

### DIFF
--- a/src/js/site/lazyLoad.js
+++ b/src/js/site/lazyLoad.js
@@ -21,12 +21,31 @@ const LazyLoading = {
 				callback_loaded: LazyLoading.mediaLoaded // eslint-disable-line camelcase
 			});
 		}
+
+		this.iOSver('.media-wrap--lazy-loader');
 	},
 
 	mediaLoaded: (el) => {
 		// hide preloader
 		$(el).parent().addClass(LazyLoading.classHidden);
-	}
+	},
+
+	iOSver: ($target) => {
+        function iOSversion() {
+            if (/iP(hone|od|ad)/.test(navigator.platform)) {
+                const v = (navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
+                return [parseInt(v[1], 10), parseInt(v[2], 10), parseInt(v[3] || 0, 10)];
+            }
+        }
+
+        const ver = iOSversion();
+
+        if (ver && ver[0] < 14) {
+            $($target).each(function(e, el) {
+                $(el).removeClass('media-wrap--lazy-loader');
+            });
+        }
+    }
 };
 
 export default LazyLoading;


### PR DESCRIPTION
I added function which checks for iOS version, and fixes the issue with lazy load, if it is version 13 or lower.

I haven't tested it on this starter theme, but I did the exact  same thing for a different project which had this issue, and it worked just fine. So, it should be ok.